### PR TITLE
Feature: add flextesa cors env

### DIFF
--- a/src/modules/flextesa/commands.ts
+++ b/src/modules/flextesa/commands.ts
@@ -40,6 +40,8 @@ export const startFlextesa = (_options: Partial<FlextesaOptions>, readyCallback?
     POD_NAME,
     "-p",
     host + ":" + port + ":20000",
+    "-e",
+    "flextesa_node_cors_origin=*",
     "tqtezos/flextesa:20210602",
     "flextesa",
     "mini-net",


### PR DESCRIPTION
Adds env to flextesa sandbox to allow deploy from localhost UI
`flextesa_node_cors_origin=*`
Affected files:
[src/modules/flextesa/commands.ts#L42-45](https://github.com/uconomy/lava/compare/main...LikoIlya:feature/cors-flag?expand=1#diff-68c000370523cc3fcf787c8ee60a846d182dfc27f9f5a998ce69edbacfe361d8)