### PR TITLE
Fix compairing versions of ligo

### DIFF
--- a/src/modules/ligo/parameters.ts
+++ b/src/modules/ligo/parameters.ts
@@ -6,11 +6,13 @@ export const isLigoVersionLT = (compare: LIGOVersions, to: LIGOVersions): boolea
   } else if (compare === to) {
     return false;
   } else {
-    for (const sToken of compare.split('.')) {
-      for (const tToken of to.split('.')) {
-        if (parseInt(sToken) < parseInt(tToken)) {
-          return true;
-        }
+    const comp_version = compare.split(".");
+    const to_version = compare.split(".");
+    for (let i = 0; i < to_version.length; i++) {
+      const sToken = comp_version[i];
+      const tToken = to_version[i];
+      if (parseInt(sToken) < parseInt(tToken)) {
+        return true;
       }
     }
 


### PR DESCRIPTION
Fix comparing wrong levels of versions at the validation of ligo versions.

The issue to reproduce:
1) compile contract with version 0.x.0
1) try to compile the contract with version 0.(x+1).0